### PR TITLE
changed to rawDescription to remove <p> tags

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -814,6 +814,8 @@
     },
     "@zeplin/cli": {
       "version": "0.3.0",
+      "resolved": "https://registry.npmjs.org/@zeplin/cli/-/cli-0.3.0.tgz",
+      "integrity": "sha512-jP1DaMz+Ltfu+cixkXY0OtlefpPHIgA7UoX8Hpf3edVHDGQj5XuBOay2c4iWHLVYzL3HRPD6flpkxIYsws3hdg==",
       "dev": true,
       "requires": {
         "@hapi/joi": "^16.1.7",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@zeplin/cli-connect-angular-plugin",
-  "version": "0.1.3",
+  "version": "0.1.4",
   "description": "Zeplin CLI Connected Components - Angular Plugin",
   "main": "./dist/index",
   "scripts": {

--- a/src/template/description-full.pug
+++ b/src/template/description-full.pug
@@ -5,8 +5,8 @@ block content
         | # #{component.name}
         +list("extends", component._extends)
         +list("implements", component._implements)
-        if component.description.length > 0
+        if component.rawDescription.length > 0
             +linebreak(1)
-            | !{component.description}
+            | !{component.rawDescription}
         if index !== (components.length - 1)
             +linebreak(2)

--- a/src/template/description-summary.pug
+++ b/src/template/description-summary.pug
@@ -3,8 +3,8 @@ extends base
 block content
     each component, index in components
         | #### #{component.name}#{(component._extends ? " extends " + component._extends : "")}
-        if component.description.length > 0
+        if component.rawDescription.length > 0
             |
-            | !{component.description}
+            | !{component.rawDescription}
         if index !== (components.length - 1)
             +linebreak(3)

--- a/test/__snapshots__/index.test.ts.snap
+++ b/test/__snapshots__/index.test.ts.snap
@@ -3,13 +3,12 @@
 exports[`Connected Components Angular Plugin component.ts snippet creation 1`] = `
 Object {
   "description": "#### BankAccount
-<p>This is a bank account component</p>
-
+This is a bank account component
+This is line 2 description
 
 
 #### BankAccountHolder
-<p>This is a bank account holder component</p>
-",
+This is a bank account holder component",
   "lang": "markup",
   "snippet": "<!--- BankAccount examples --->
 <!--- Possible selectors:
@@ -35,13 +34,11 @@ Object {
 exports[`Connected Components Angular Plugin componentWithDecoratorInputs.ts snippet creation 1`] = `
 Object {
   "description": "#### BankAccount
-<p>This is a bank account component</p>
-
+This is a bank account component
 
 
 #### BankAccountHolder
-<p>This is a bank account holder component</p>
-",
+This is a bank account holder component",
   "lang": "markup",
   "snippet": "<!--- BankAccount examples --->
 <!--- Possible selectors:
@@ -67,13 +64,11 @@ Object {
 exports[`Connected Components Angular Plugin componentWithFileTemplate.ts snippet creation 1`] = `
 Object {
   "description": "#### BankAccount
-<p>This is a bank account component</p>
-
+This is a bank account component
 
 
 #### BankAccountHolder
-<p>This is a bank account holder component</p>
-",
+This is a bank account holder component",
   "lang": "markup",
   "snippet": "<!--- BankAccount examples --->
 <!--- Possible selectors:
@@ -99,13 +94,11 @@ Object {
 exports[`Connected Components Angular Plugin componentWithMultiSelectors.ts snippet creation 1`] = `
 Object {
   "description": "#### BankAccount
-<p>This is a bank account component</p>
-
+This is a bank account component
 
 
 #### BankAccountHolder
-<p>This is a bank account holder component</p>
-",
+This is a bank account holder component",
   "lang": "markup",
   "snippet": "<!--- BankAccount examples --->
 <!--- Possible selectors:
@@ -134,12 +127,10 @@ Object {
 exports[`Connected Components Angular Plugin componentWithMultiSelectors.ts snippet creation 2`] = `
 Object {
   "description": "# BankAccount
-<p>This is a bank account component</p>
-
+This is a bank account component
 
 # BankAccountHolder
-<p>This is a bank account holder component</p>
-",
+This is a bank account holder component",
   "lang": "markup",
   "snippet": "<!--- BankAccount examples --->
 <bank-account

--- a/test/samples/component.ts
+++ b/test/samples/component.ts
@@ -1,5 +1,6 @@
 /**
  * This is a bank account component
+ * This is line 2 description
  */
 @Component({
   selector: 'bank-account',


### PR DESCRIPTION
Fixes https://github.com/zeplin/cli/issues/27

Use **rawDescription** instead of **description** generated from compodoc which uses \n instead of &lt;p> tags which prevent the description from being displayed