### PR TITLE
Prefer local binaries when running execa

### DIFF
--- a/src/index.ts
+++ b/src/index.ts
@@ -202,7 +202,13 @@ export default class implements ConnectPlugin {
         const tsConfigPath = path.resolve(this.config.tsConfigPath || "");
 
         try {
-            const { stdout } = await execa.command(`compodoc -p ${tsConfigPath} -e json -d ${outputDirPath}`);
+            const { stdout } = await execa.command(
+                `compodoc -p ${tsConfigPath} -e json -d ${outputDirPath}`,
+                {
+                    preferLocal: true,
+                    localDir: __dirname
+                }
+            );
 
             logger.debug(`compodoc output: ${stdout}`);
 


### PR DESCRIPTION
## Change description

This change makes execa use the local compodoc binary.

## Type of change
- [X] Bug fix (fixes an issue)
- [ ] New feature (adds functionality)

## Related issues

Fixes #15
JIRA: ZCLI-47

## Checklists

### Development

- [X] Lint rules pass locally
- [X] Application changes have been tested thoroughly
- [ ] Automated tests covering modified code pass

### Security

- [X] Security impact of change has been considered
- [X] Code follows company security practices and guidelines

### Code review 

- [X] Pull request has a descriptive title and context useful to a reviewer. Screenshots or screencasts are attached as necessary
- [X] "Ready for review" label attached and reviewers assigned
- [ ] Changes have been reviewed by at least one other contributor
- [ ] Pull request linked to task tracker where applicable
